### PR TITLE
Updated URL and selector in demo2 due to ynet changes

### DIFF
--- a/03-hello-python-world/demo2.py
+++ b/03-hello-python-world/demo2.py
@@ -1,8 +1,8 @@
 import requests
 from bs4 import BeautifulSoup
 
-url = 'https://www.ynet.co.il/home/0,7340,L-184,00.html'
+url = 'https://www.ynet.co.il/news/category/184'
 r = requests.get(url)
-soup = BeautifulSoup(r.text)
-for link in soup.select('a.smallheader'):
-    print(link.text)
+soup = BeautifulSoup(r.text, features='html.parser')
+for title in soup.select('div.title'):
+    print(title.text)


### PR DESCRIPTION
Current  demo2 script from [lessons 03-hello-python-world](https://www.tocode.co.il/bundles/28/lessons/03-hello-python-world) doesn't work due to ynet changes.

Needed update:
- BeautifulSoup selector mast be updated.

Optional updates:

- To avoid UserWarning from BeautifulSoup, specify parser.
- Update [new ynet URL](https://www.ynet.co.il/news/category/184) (currently redirected from [old URL](https://www.ynet.co.il/home/0,7340,L-184,00.html)).
